### PR TITLE
Additional constructor and iteration

### DIFF
--- a/src/MutableNamedTuples.jl
+++ b/src/MutableNamedTuples.jl
@@ -5,7 +5,12 @@ export MutableNamedTuple
 struct MutableNamedTuple{N,T <: Tuple{Vararg{<:Ref}}}
     nt::NamedTuple{N, T}
 end
+
 MutableNamedTuple(;kwargs...) = MutableNamedTuple(NamedTuple{keys(kwargs.data)}(Ref.(values(kwargs.data))))
+
+function MutableNamedTuple{names}(tuple::Tuple) where names
+    MutableNamedTuple(NamedTuple{names}(Ref.(tuple)))
+end
 
 Base.keys(::MutableNamedTuple{names}) where {names} = names 
 Base.values(mnt::MutableNamedTuple) = (x -> x[]).(values(getfield(mnt, :nt)))
@@ -26,5 +31,14 @@ function Base.setproperty!(mnt::MutableNamedTuple, s::Symbol, x)
     refvalues(mnt)[i][] = x
 end
 
+Base.length(mnt::MutableNamedTuple) = length(getfield(mnt, :nt))
+Base.iterate(mnt::MutableNamedTuple, iter=1) = iterate(NamedTuple(mnt), iter)
+Base.firstindex(mnt::MutableNamedTuple) = 1
+Base.lastindex(mnt::MutableNamedTuple) = lastindex(NamedTuple(mnt))
+Base.getindex(mnt::MutableNamedTuple, i::Int) = getfield(NamedTuple(mnt), i)
+Base.getindex(mnt::MutableNamedTuple, i::Symbol) = getfield(NamedTuple(mnt), i)
+function Base.indexed_iterate(mnt::MutableNamedTuple, i::Int, state=1) 
+    Base.indexed_iterate(NamedTuple(mnt), i, state) 
+end
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,4 +7,15 @@ using Test, MutableNamedTuples
 
     @test mnt.a == 2
     @test NamedTuple(mnt) == (;a=2, b="hi")
+    @test collect(mnt) == [2;"hi"]
+    @test length(mnt) == 2 
+    @test mnt[1] == 2
+    @test mnt[2] == "hi"
+    @test mnt[:a] == 2
+    @test mnt[:b] == "hi"
+
+    mnt2 = MutableNamedTuple{(:a,:b)}((2,"hi"))
+    @test NamedTuple(mnt2) == NamedTuple(mnt)
 end
+
+


### PR DESCRIPTION
Hi Mason,

Thanks for this fun package! In this pull request I added two minor "features": First, `NamedTuple` has the following constructor
```julia
NamedTuple{names}(args::Tuple) where {names}
```
Now this also works with `MutableNamedTuple`. The second change is to enable iteration (e.g. to `collect` a `MutableNamedTuple`) and indexing.
