### PR TITLE
Use getindex directly in Base.values

### DIFF
--- a/src/MutableNamedTuples.jl
+++ b/src/MutableNamedTuples.jl
@@ -13,7 +13,7 @@ function MutableNamedTuple{names}(tuple::Tuple) where names
 end
 
 Base.keys(::MutableNamedTuple{names}) where {names} = names 
-Base.values(mnt::MutableNamedTuple) = (x -> x[]).(values(getfield(mnt, :nt)))
+Base.values(mnt::MutableNamedTuple) = getindex.(values(getfield(mnt, :nt)))
 refvalues(mnt::MutableNamedTuple) = values(getfield(mnt, :nt))
 
 Base.NamedTuple(mnt::MutableNamedTuple) = NamedTuple{keys(mnt)}(values(mnt))


### PR DESCRIPTION
Optional, as the generated code is identical, but thought this would be clearer as the meaning is more direct than using an anonymous function.

Unrelated:
What does `Base.indexed_iterate` do in this package? 