### PR TITLE
use values() and keys() on kwargs to avoid warning on Julia >= 1.7

### DIFF
--- a/src/MutableNamedTuples.jl
+++ b/src/MutableNamedTuples.jl
@@ -6,7 +6,7 @@ struct MutableNamedTuple{N,T <: Tuple{Vararg{<:Ref}}}
     nt::NamedTuple{N, T}
 end
 
-MutableNamedTuple(;kwargs...) = MutableNamedTuple(NamedTuple{keys(kwargs.data)}(Ref.(values(kwargs.data))))
+MutableNamedTuple(; kwargs...) = MutableNamedTuple(NamedTuple{keys(kwargs)}(Ref.(values(values(kwargs)))))
 
 function MutableNamedTuple{names}(tuple::Tuple) where names
     MutableNamedTuple(NamedTuple{names}(Ref.(tuple)))


### PR DESCRIPTION
Hello, 
I have the following warning when creating a  `MutableNamedTuple` using kwargs on Julia now that I updated to Julia 1.7:

```julia
>julia MutableNamedTuple(a = 1)
Warning: use values(kwargs) and keys(kwargs) instead of kwargs.data and kwargs.itr
│   caller = #MutableNamedTuple#7 at MutableNamedTuples.jl:9 [inlined]
```

Here's a PR that fixes the warning. 