### PR TITLE
Added propertynames and changed setproperty!

### DIFF
--- a/src/MutableNamedTuples.jl
+++ b/src/MutableNamedTuples.jl
@@ -27,9 +27,10 @@ end
 Base.getproperty(mnt::MutableNamedTuple, s::Symbol) = getproperty(NamedTuple(mnt), s)
 
 function Base.setproperty!(mnt::MutableNamedTuple, s::Symbol, x)
-    i = findfirst(x -> x === s, keys(mnt))
-    refvalues(mnt)[i][] = x
+    nt = getfield(mnt,:nt)
+    getfield(nt,s)[] = x
 end
+Base.propertynames(::MutableNamedTuple{T,R}) where {T,R} = T
 
 Base.length(mnt::MutableNamedTuple) = length(getfield(mnt, :nt))
 Base.iterate(mnt::MutableNamedTuple, iter=1) = iterate(NamedTuple(mnt), iter)


### PR DESCRIPTION
This is a small modification from my fork 1 year ago.

Changed `setproperty!` to speed up access (closes #5)

Also added `propertynames` to provide tab-completion of names from REPL .