### PR TITLE
Make `getproperty` access just one value (instead of all)

### DIFF
--- a/src/MutableNamedTuples.jl
+++ b/src/MutableNamedTuples.jl
@@ -24,7 +24,7 @@ function Base.show(io::IO, mnt::MutableNamedTuple{names}) where {names}
     print(io, "MutableNamedTuple", NamedTuple(mnt))
 end
 
-Base.getproperty(mnt::MutableNamedTuple, s::Symbol) = getproperty(NamedTuple(mnt), s)
+Base.getproperty(mnt::MutableNamedTuple, s::Symbol) = getfield(getfield(mnt, :nt), s)[]
 
 function Base.setproperty!(mnt::MutableNamedTuple, s::Symbol, x)
     nt = getfield(mnt,:nt)


### PR DESCRIPTION
Fixes #8.

See the benchmarking there: in the second benchmark (with a `MutableNamedTuple` of 201 values), property access was sped up by 7x.

Tests for this commit (5a314fa), on my laptop (Julia 1.8.1):
```julia
Test Summary: | Pass  Total  Time
tests         |   10     10  0.5s
     Testing MutableNamedTuples tests passed
```