### PR TITLE
Added shorthand `const MNT = MutableNamedTuple`

### DIFF
--- a/README.org
+++ b/README.org
@@ -17,10 +17,9 @@ julia> mnt
 MutableNamedTuple(a = 2, b = 2)
 #+END_SRC
 
-#+BEGIN_SRC julia
-julia> const MNT = MutableNamedTuple
-MutableNamedTuple
+A shorthand ~MNT~ can also be used:
 
+#+BEGIN_SRC julia
 julia> A = [MNT(a = 1, b=2) MNT(a=3, b=6)
             MNT(a =-1, b=4) MNT(a=1, b=1)]
 2×2 Array{MutableNamedTuple{(:a, :b),Tuple{Base.RefValue{Int64},Base.RefValue{Int64}}},2}:

--- a/src/MutableNamedTuples.jl
+++ b/src/MutableNamedTuples.jl
@@ -1,6 +1,6 @@
 module MutableNamedTuples
 
-export MutableNamedTuple
+export MutableNamedTuple, MNT
 
 struct MutableNamedTuple{N,T <: Tuple{Vararg{<:Ref}}}
     nt::NamedTuple{N, T}
@@ -11,6 +11,8 @@ MutableNamedTuple(; kwargs...) = MutableNamedTuple(NamedTuple{keys(kwargs)}(Ref.
 function MutableNamedTuple{names}(tuple::Tuple) where names
     MutableNamedTuple(NamedTuple{names}(Ref.(tuple)))
 end
+
+const MNT = MutableNamedTuple
 
 Base.keys(::MutableNamedTuple{names}) where {names} = names 
 Base.values(mnt::MutableNamedTuple) = getindex.(values(getfield(mnt, :nt)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,12 @@ using Test, MutableNamedTuples
 
     mnt2 = MutableNamedTuple{(:a,:b)}((2,"hi"))
     @test NamedTuple(mnt2) == NamedTuple(mnt)
+
+    mnt3 = MNT(a=1, b="hi")
+    @test mnt3 isa MutableNamedTuple
+    mnt3.a = 2
+    @test mnt3.a == 2
+    @test mnt3[2] == "hi"
 end
 
 


### PR DESCRIPTION
I explicitly added the `MNT` shorthand that's defined in the README.